### PR TITLE
Move annotation related methods in TSDB into MetaClient

### DIFF
--- a/src/core/MetaClient.java
+++ b/src/core/MetaClient.java
@@ -1,0 +1,153 @@
+package net.opentsdb.core;
+
+import java.util.List;
+
+import net.opentsdb.meta.Annotation;
+import net.opentsdb.storage.TsdbStore;
+import net.opentsdb.uid.UniqueId;
+
+import com.google.common.base.Strings;
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MetaClient {
+  private static final Logger LOG = LoggerFactory.getLogger(MetaClient.class);
+
+  private final TsdbStore tsdbStore;
+
+  public MetaClient(final TsdbStore tsdb_store) {
+    this.tsdbStore = checkNotNull(tsdb_store);
+  }
+
+  /**
+   * Scans through the global annotation storage rows and returns a list of
+   * parsed annotation objects. If no annotations were found for the given
+   * timespan, the resulting list will be empty.
+   * @param start_time Start time to scan from. May be 0
+   * @param end_time End time to scan to. Must be greater than 0
+   * @return A list with detected annotations. May be empty.
+   * @throws IllegalArgumentException if the end timestamp has not been set or
+   * the end time is less than the start time
+   */
+  public Deferred<List<Annotation>> getGlobalAnnotations(final long start_time, final long end_time) {
+    if (end_time < 1) {
+      throw new IllegalArgumentException("The end timestamp has not been set");
+    }
+    if (end_time < start_time) {
+      throw new IllegalArgumentException(
+          "The end timestamp cannot be less than the start timestamp");
+    }
+
+    return tsdbStore.getGlobalAnnotations(start_time, end_time);
+  }
+
+  /**
+   * Attempts to fetch a global or local annotation from storage
+   * @param tsuid The TSUID as a string. May be empty if retrieving a global
+   * annotation
+   * @param start_time The start time as a Unix epoch timestamp
+   * @return A valid annotation object if found, null if not
+   */
+  public Deferred<Annotation> getAnnotation(final String tsuid, final long start_time) {
+    if (Strings.isNullOrEmpty(tsuid)) {
+      return tsdbStore.getAnnotation(null, start_time);
+    }
+
+    return tsdbStore.getAnnotation(UniqueId.stringToUid(tsuid), start_time);
+  }
+
+  /**
+   * Attempts to mark an Annotation object for deletion. Note that if the
+   * annotation does not exist in storage, this delete call will not throw an
+   * error.
+   *
+   * @param annotation The Annotation we want to store.
+   * @param tsdb
+   * @return A meaningless Deferred for the caller to wait on until the call is
+   * complete. The value may be null.
+   */
+  public Deferred<Object> delete(Annotation annotation) {
+    if (annotation.getStartTime() < 1) {
+      throw new IllegalArgumentException("The start timestamp has not been set");
+    }
+
+    return tsdbStore.delete(annotation);
+  }
+
+  /**
+   * Attempts a CompareAndSet storage call, loading the object from storage,
+   * synchronizing changes, and attempting a put.
+   * <b>Note:</b> If the local object didn't have any fields set by the caller
+   * or there weren't any changes, then the data will not be written and an
+   * exception will be thrown.
+   * @param annotation The The Annotation we want to store.
+   * @param overwrite When the RPC method is PUT, will overwrite all user
+   * accessible fields
+   * True if the storage call was successful, false if the object was
+   * modified in storage during the CAS call. If false, retry the call. Other
+   * failures will result in an exception being thrown.
+   * @param tsdb
+   * @throws IllegalArgumentException if required data was missing such as the
+   * {@code #start_time}
+   * @throws IllegalStateException if the data hasn't changed. This is OK!
+   * @throws net.opentsdb.utils.JSONException if the object could not be serialized
+   */
+  public Deferred<Boolean> syncToStorage(final Annotation annotation,
+                                         final boolean overwrite) {
+    if (annotation.getStartTime() < 1) {
+      throw new IllegalArgumentException("The start timestamp has not been set");
+    }
+
+    if (!annotation.hasChanges()) {
+      LOG.debug("{} does not have changes, skipping sync to storage", annotation);
+      throw new IllegalStateException("No changes detected in Annotation data");
+    }
+
+    final class StoreCB implements Callback<Deferred<Boolean>, Annotation> {
+      @Override
+      public Deferred<Boolean> call(final Annotation stored_note)
+        throws Exception {
+        if (stored_note != null) {
+          annotation.syncNote(stored_note, overwrite);
+        }
+
+        return tsdbStore.updateAnnotation(stored_note, annotation);
+      }
+    }
+
+    final byte[] tsuid;
+    if (Strings.isNullOrEmpty(annotation.getTSUID())) {
+      tsuid = null;
+    } else {
+      tsuid = UniqueId.stringToUid(annotation.getTSUID());
+    }
+
+    return tsdbStore.getAnnotation(tsuid, annotation.getStartTime()).addCallbackDeferring(new StoreCB());
+  }
+
+  /**
+   * Deletes global or TSUID associated annotiations for the given time range.
+   * @param tsuid An optional TSUID. If set to null, then global annotations for
+   * the given range will be deleted
+   * @param start_time A start timestamp in milliseconds
+   * @param end_time An end timestamp in millseconds
+   * @return The number of annotations deleted
+   * @throws IllegalArgumentException if the timestamps are invalid
+   * @since 2.1
+   */
+  public Deferred<Integer> deleteRange(final byte[] tsuid, final long start_time, final long end_time) {
+    if (end_time < 1) {
+      throw new IllegalArgumentException("The end timestamp has not been set");
+    }
+    if (end_time < start_time) {
+      throw new IllegalArgumentException(
+          "The end timestamp cannot be less than the start timestamp");
+    }
+
+    return tsdbStore.deleteAnnotationRange(tsuid, start_time, end_time);
+  }
+}

--- a/src/tsd/QueryRpc.java
+++ b/src/tsd/QueryRpc.java
@@ -149,7 +149,7 @@ final class QueryRpc implements HttpRpc {
     List<Annotation> globals = null;
     if (!data_query.getNoAnnotations() && data_query.getGlobalAnnotations()) {
       try {
-        globals = tsdb.getGlobalAnnotations(
+        globals = tsdb.getMetaClient().getGlobalAnnotations(
                 data_query.startTime() / 1000, data_query.endTime() / 1000)
             .joinUninterruptibly();
       } catch (Exception e) {

--- a/test/core/MetaClientAnnotationTest.java
+++ b/test/core/MetaClientAnnotationTest.java
@@ -1,52 +1,37 @@
-// This file is part of OpenTSDB.
-// Copyright (C) 2010-2012  The OpenTSDB Authors.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or (at your
-// option) any later version.  This program is distributed in the hope that it
-// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
-// General Public License for more details.  You should have received a copy
-// of the GNU Lesser General Public License along with this program.  If not,
-// see <http://www.gnu.org/licenses/>.
-package net.opentsdb.meta;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+package net.opentsdb.core;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import net.opentsdb.meta.Annotation;
 import net.opentsdb.storage.MemoryStore;
-import net.opentsdb.core.TSDB;
 import net.opentsdb.storage.MockBase;
 import net.opentsdb.storage.json.StorageModule;
 import net.opentsdb.uid.UniqueId;
 import net.opentsdb.utils.Config;
-import net.opentsdb.utils.JSON;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import org.junit.Before;
 import org.junit.Test;
 
-public final class TestAnnotation {
+import static org.junit.Assert.*;
+
+public class MetaClientAnnotationTest {
+  private Annotation note;
   private TSDB tsdb;
   private MemoryStore tsdb_store;
-  private Annotation note = new Annotation();
-  
-  final private byte[] global_row_key = 
-      new byte[] { 0, 0, 0, (byte) 0x4F, (byte) 0x29, (byte) 0xD2, 0 };
-  final private byte[] tsuid_row_key = 
-      new byte[] { 0, 0, 1, (byte) 0x52, (byte) 0xC2, (byte) 0x09, 0, 0, 0, 
-        1, 0, 0, 1 };
-  
+
+  final private byte[] tsuid_row_key =
+          new byte[] { 0, 0, 1, (byte) 0x52, (byte) 0xC2, (byte) 0x09, 0, 0, 0,
+                  1, 0, 0, 1 };
+
   @Before
   public void before() throws Exception {
     final Config config = new Config(false);
     tsdb_store = new MemoryStore();
     tsdb = new TSDB(tsdb_store, config);
+
+    note = new Annotation();
 
     final ObjectMapper jsonMapper = new ObjectMapper();
     jsonMapper.registerModule(new StorageModule());
@@ -84,36 +69,62 @@ public final class TestAnnotation {
 
     // add some data points too maybe not relevant any more
     tsdb_store.addColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}, new byte[]{1});
-    
+            new byte[]{0x50, 0x10}, new byte[]{1});
+
     tsdb_store.addColumn(tsuid_row_key,
-      new byte[]{0x50, 0x18}, new byte[]{2});
+            new byte[]{0x50, 0x18}, new byte[]{2});
+  }
+
+  @Test
+  public void getGlobalAnnotations() throws Exception {
+    List<Annotation> notes = tsdb.getMetaClient().getGlobalAnnotations(1328140000,
+            1328141000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    assertNotNull(notes);
+    assertEquals(2, notes.size());
+  }
+
+  @Test
+  public void getGlobalAnnotationsEmpty() throws Exception {
+    List<Annotation> notes = tsdb.getMetaClient().getGlobalAnnotations(1328150000,
+            1328160000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    assertNotNull(notes);
+    assertEquals(0, notes.size());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void getGlobalAnnotationsZeroEndtime() throws Exception {
+    tsdb.getMetaClient().getGlobalAnnotations(0, 0).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void getGlobalAnnotationsEndLessThanStart() throws Exception {
+    tsdb.getMetaClient().getGlobalAnnotations(1328150000, 1328140000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
   }
 
   @Test
   public void getAnnotation() throws Exception {
-    note = tsdb.getAnnotation("000001000001000001", 1388450562L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    note = tsdb.getMetaClient().getAnnotation("000001000001000001", 1388450562L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertNotNull(note);
     assertEquals("000001000001000001", note.getTSUID());
     assertEquals("Hello!", note.getDescription());
     assertEquals(1388450562L, note.getStartTime());
   }
-  
+
   @Test
   public void getAnnotationNormalizeMs() throws Exception {
-    note = tsdb.getAnnotation("000001000001000001", 1388450562000L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    note = tsdb.getMetaClient().getAnnotation("000001000001000001", 1388450562000L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertNotNull(note);
     assertEquals("000001000001000001", note.getTSUID());
     assertEquals("Hello!", note.getDescription());
     assertEquals(1388450562L, note.getStartTime());
   }
-  
+
   @Test
   public void getAnnotationGlobal() throws Exception {
-    note = tsdb.getAnnotation(null, 1328140800000L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    note = tsdb.getMetaClient().getAnnotation(null, 1328140800000L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertNotNull(note);
     assertEquals("", note.getTSUID());
     assertEquals("Description", note.getDescription());
@@ -122,129 +133,30 @@ public final class TestAnnotation {
 
   @Test
   public void getAnnotationNotFound() throws Exception {
-    note = tsdb.getAnnotation("000001000001000001", 1388450564L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    note = tsdb.getMetaClient().getAnnotation("000001000001000001", 1388450564L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertNull(note);
   }
-  
+
   @Test
   public void getAnnotationGlobalNotFound() throws Exception {
-    note = tsdb.getAnnotation(null, 1388450563L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    note = tsdb.getMetaClient().getAnnotation(null, 1388450563L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertNull(note);
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void getAnnotationNoStartTime() throws Exception {
-    tsdb.getAnnotation("000001000001000001", 0L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-  }
-  
-  @Test
-  public void getGlobalAnnotations() throws Exception {
-    List<Annotation> notes = tsdb.getGlobalAnnotations(1328140000,
-            1328141000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-    assertNotNull(notes);
-    assertEquals(2, notes.size());
-  }
-  
-  @Test
-  public void getGlobalAnnotationsEmpty() throws Exception {
-    List<Annotation> notes = tsdb.getGlobalAnnotations(1328150000,
-            1328160000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-    assertNotNull(notes);
-    assertEquals(0, notes.size());
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void getGlobalAnnotationsZeroEndtime() throws Exception {
-    tsdb.getGlobalAnnotations(0, 0).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void getGlobalAnnotationsEndLessThanStart() throws Exception {
-    tsdb.getGlobalAnnotations(1328150000, 1328140000).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().getAnnotation("000001000001000001", 0L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
   }
 
-  @Test
-  public void syncToStorage() throws Exception {
-    note.setTSUID("000001000001000001");
-    note.setStartTime(1388450562L);
-    note.setDescription("Synced!");
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    note = tsdb_store.getAnnotation(UniqueId.stringToUid(note.getTSUID()),
-            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    assertEquals("000001000001000001", note.getTSUID());
-    assertEquals("Synced!", note.getDescription());
-    assertEquals("My Notes", note.getNotes());
-  }
-  
-  @Test
-  public void syncToStorageMilliseconds() throws Exception {
-    note.setTSUID("000001000001000001");
-    note.setStartTime(1388450562500L);
-    note.setDescription("Synced!");
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    note = tsdb_store.getAnnotation(UniqueId.stringToUid(note.getTSUID()),
-            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    assertEquals("000001000001000001", note.getTSUID());
-    assertEquals("Synced!", note.getDescription());
-    assertEquals("", note.getNotes());
-    assertEquals(1388450562500L, note.getStartTime());
-  }
-  
-  @Test
-  public void syncToStorageGlobal() throws Exception {
-    note.setStartTime(1328140800L);
-    note.setDescription("Synced!");
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    note = tsdb_store.getAnnotation(null,
-            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    assertEquals("", note.getTSUID());
-    assertEquals("Synced!", note.getDescription());
-    assertEquals("Notes", note.getNotes());
-  }
-  
-  @Test
-  public void syncToStorageGlobalMilliseconds() throws Exception {
-    note.setStartTime(1328140800500L);
-    note.setDescription("Synced!");
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    note = tsdb_store.getAnnotation(null,
-            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-
-    assertEquals("", note.getTSUID());
-    assertEquals("Synced!", note.getDescription());
-    assertEquals("", note.getNotes());
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void syncToStorageMissingStart() throws Exception {
-    note.setTSUID("000001000001000001");
-    note.setDescription("Synced!");
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-  }
-  
-  @Test (expected = IllegalStateException.class)
-  public void syncToStorageNoChanges() throws Exception {
-    note.setTSUID("000001000001000001");
-    note.setStartTime(1388450562L);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
-  }
-  
   @Test
   public void delete() throws Exception {
     final long start_time = 1388450562;
     note.setTSUID("000001000001000001");
     note.setStartTime(start_time);
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     assertNull(tsdb_store.getAnnotation(
             UniqueId.stringToUid(note.getTSUID()),
@@ -260,17 +172,17 @@ public final class TestAnnotation {
 
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[]{0x50, 0x18}));
   }
-  
+
   @Test
   public void deleteNormalizeMs() throws Exception {
     note.setTSUID("000001000001000001");
     note.setStartTime(1388450562000L);
 
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     assertNull(tsdb_store.getAnnotation(
             UniqueId.stringToUid(note.getTSUID()),
@@ -285,18 +197,18 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[] { 0x50, 0x18 }));
   }
-  
+
   // this doesn't throw an error or anything, just issues the delete request
   // and it's ignored.
   @Test
   public void deleteNotFound() throws Exception {
     note.setTSUID("000001000001000001");
     note.setStartTime(1388450561);
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
 
     note.setStartTime(1388450562);
@@ -312,21 +224,21 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[] { 0x50, 0x18 }));
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void deleteMissingStart() throws Exception {
     note.setTSUID("000001000001000001");
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
   }
-  
+
   @Test
   public void deleteGlobal() throws Exception {
     note.setStartTime(1328140800);
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     assertNull(tsdb_store.getAnnotation(null,
             note.getStartTime()
@@ -337,11 +249,11 @@ public final class TestAnnotation {
             note.getStartTime()
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
   }
-  
+
   @Test
   public void deleteGlobalNotFound() throws Exception {
     note.setStartTime(1328140803);
-    tsdb.delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().delete(note).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     note.setStartTime(1328140800);
     assertNotNull(tsdb_store.getAnnotation(null,
@@ -354,12 +266,86 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
   }
-  
+
+  @Test
+  public void syncToStorage() throws Exception {
+    note.setTSUID("000001000001000001");
+    note.setStartTime(1388450562L);
+    note.setDescription("Synced!");
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    note = tsdb_store.getAnnotation(UniqueId.stringToUid(note.getTSUID()),
+            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    assertEquals("000001000001000001", note.getTSUID());
+    assertEquals("Synced!", note.getDescription());
+    assertEquals("My Notes", note.getNotes());
+  }
+
+  @Test
+  public void syncToStorageMilliseconds() throws Exception {
+    note.setTSUID("000001000001000001");
+    note.setStartTime(1388450562500L);
+    note.setDescription("Synced!");
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase
+            .DEFAULT_TIMEOUT);
+
+    note = tsdb_store.getAnnotation(UniqueId.stringToUid(note.getTSUID()),
+            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    assertEquals("000001000001000001", note.getTSUID());
+    assertEquals("Synced!", note.getDescription());
+    assertEquals("", note.getNotes());
+    assertEquals(1388450562500L, note.getStartTime());
+  }
+
+  @Test
+  public void syncToStorageGlobal() throws Exception {
+    note.setStartTime(1328140800L);
+    note.setDescription("Synced!");
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    note = tsdb_store.getAnnotation(null,
+            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    assertEquals("", note.getTSUID());
+    assertEquals("Synced!", note.getDescription());
+    assertEquals("Notes", note.getNotes());
+  }
+
+  @Test
+  public void syncToStorageGlobalMilliseconds() throws Exception {
+    note.setStartTime(1328140800500L);
+    note.setDescription("Synced!");
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    note = tsdb_store.getAnnotation(null,
+            note.getStartTime()).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+
+    assertEquals("", note.getTSUID());
+    assertEquals("Synced!", note.getDescription());
+    assertEquals("", note.getNotes());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void syncToStorageMissingStart() throws Exception {
+    note.setTSUID("000001000001000001");
+    note.setDescription("Synced!");
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+  }
+
+  @Test (expected = IllegalStateException.class)
+  public void syncToStorageNoChanges() throws Exception {
+    note.setTSUID("000001000001000001");
+    note.setStartTime(1388450562L);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+  }
+
   @Test
   public void deleteRange() throws Exception {
     note.setTSUID("000001000001000001");
 
-    final int count = tsdb.deleteRange(
+    final int count = tsdb.getMetaClient().deleteRange(
             UniqueId.stringToUid(note.getTSUID()), 1388450560000L,
             1388450562000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(1, count);
@@ -377,15 +363,15 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[] { 0x50, 0x18 }));
   }
-  
+
   @Test
   public void deleteRangeNone() throws Exception {
     note.setTSUID("000001000001000001");
-    final int count = tsdb.deleteRange(
+    final int count = tsdb.getMetaClient().deleteRange(
             UniqueId.stringToUid(note.getTSUID()), 1388450560000L,
             1388450561000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(0, count);
@@ -403,15 +389,15 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[] { 0x50, 0x18 }));
   }
-  
+
   @Test
   public void deleteRangeMultiple() throws Exception {
     note.setTSUID("000001000001000001");
-    final int count = tsdb.deleteRange(
+    final int count = tsdb.getMetaClient().deleteRange(
             new byte[]{0, 0, 1, 0, 0, 1, 0, 0, 1}, 1388450560000L,
             1388450568000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(2, count);
@@ -429,14 +415,14 @@ public final class TestAnnotation {
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-      new byte[]{0x50, 0x10}));
+            new byte[]{0x50, 0x10}));
     assertNotNull(tsdb_store.getColumn(tsuid_row_key,
-        new byte[] { 0x50, 0x18 }));
+            new byte[] { 0x50, 0x18 }));
   }
-  
+
   @Test
   public void deleteRangeGlobal() throws Exception {
-    final int count = tsdb.deleteRange(null, 1328140799000L,
+    final int count = tsdb.getMetaClient().deleteRange(null, 1328140799000L,
             1328140800000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(1, count);
 
@@ -450,10 +436,10 @@ public final class TestAnnotation {
             note.getStartTime()
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
   }
-  
+
   @Test
   public void deleteRangeGlobalNone() throws Exception {
-    final int count = tsdb.deleteRange(null, 1328140798000L,
+    final int count = tsdb.getMetaClient().deleteRange(null, 1328140798000L,
             1328140799000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(0, count);
     note.setStartTime(1328140800);
@@ -466,10 +452,10 @@ public final class TestAnnotation {
             note.getStartTime()
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
   }
-  
+
   @Test
   public void deleteRangeGlobalMultiple() throws Exception {
-    final int count = tsdb.deleteRange(null, 1328140799000L,
+    final int count = tsdb.getMetaClient().deleteRange(null, 1328140799000L,
             1328140900000L).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals(2, count);
     note.setStartTime(1328140800);
@@ -482,15 +468,15 @@ public final class TestAnnotation {
             note.getStartTime()
     ).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
   }
-  
+
   @Test (expected = IllegalArgumentException.class)
   public void deleteRangeEmptyEnd() throws Exception {
-    tsdb.deleteRange(null, 1328140799000L, 0).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().deleteRange(null, 1328140799000L, 0).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
   }
 
   @Test (expected = IllegalArgumentException.class)
   public void deleteRangeEndLessThanStart() throws Exception {
-    tsdb.deleteRange(null, 1328140799000L, 1328140798000L)
-      .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().deleteRange(null, 1328140799000L, 1328140798000L)
+            .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
   }
 }

--- a/test/core/TestTSDBExecuteQuery.java
+++ b/test/core/TestTSDBExecuteQuery.java
@@ -826,7 +826,8 @@ public final class TestTSDBExecuteQuery {
     note.setTSUID(TSUID_1);
     note.setStartTime(START_TIME_3);
     note.setDescription(DESCRIPTION);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase
+            .DEFAULT_TIMEOUT);
 
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put(HOST, WEB_01);
@@ -857,7 +858,7 @@ public final class TestTSDBExecuteQuery {
     note.setTSUID(TSUID_1);
     note.setStartTime(START_TIME_3);
     note.setDescription(DESCRIPTION);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     final Field compact = Config.class.getDeclaredField(ENABLE_COMPACTIONS);
     compact.setAccessible(true);
@@ -911,7 +912,7 @@ public final class TestTSDBExecuteQuery {
     note.setTSUID(TSUID_1);
     note.setStartTime(START_TIME_4);
     note.setDescription(DESCRIPTION);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put(HOST, WEB_01);
@@ -947,7 +948,7 @@ public final class TestTSDBExecuteQuery {
     note.setTSUID(TSUID_1);
     note.setStartTime(START_TIME_4);
     note.setDescription(DESCRIPTION);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     HashMap<String, String> tags = new HashMap<String, String>(1);
     tags.put(HOST, WEB_01);
@@ -1000,7 +1001,7 @@ public final class TestTSDBExecuteQuery {
     note.setTSUID(TSUID_1);
     note.setStartTime(START_TIME_4);
     note.setDescription(DESCRIPTION);
-    tsdb.syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(note, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
 
     queryBuilder.withStartAndEndTime(START_TIME_1,END_TIME_1);
     final List<String> tsuids = new ArrayList<String>(1);

--- a/test/tools/TestDumpSeries.java
+++ b/test/tools/TestDumpSeries.java
@@ -307,7 +307,7 @@ public class TestDumpSeries {
     annotation.setStartTime(timestamp);
     annotation.setTSUID("000001000001000001");
     annotation.setDescription("Annotation on seconds");
-    tsdb.syncToStorage(annotation, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(annotation, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     
     tsdb.addPoint("sys.cpu.user", timestamp++, 42, tags).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     tsdb.addPoint("sys.cpu.user", timestamp++, 257, tags).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
@@ -323,7 +323,7 @@ public class TestDumpSeries {
     annotation.setStartTime(timestamp);
     annotation.setTSUID("000001000001000001");
     annotation.setDescription("Annotation on milliseconds");
-    tsdb.syncToStorage(annotation, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
+    tsdb.getMetaClient().syncToStorage(annotation, false).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     
     tsdb.addPoint("sys.cpu.user", timestamp, 42, tags).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     tsdb.addPoint("sys.cpu.user", timestamp += 1000, 257, tags).joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);

--- a/test/tsd/TestAnnotationRpc.java
+++ b/test/tsd/TestAnnotationRpc.java
@@ -205,7 +205,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_ONE_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
 
-    Annotation a = tsdb.getAnnotation("000001000001000001",1388450564)
+    Annotation a = tsdb.getMetaClient().getAnnotation("000001000001000001", 1388450564)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals("Boo", a.getDescription());
   }
@@ -227,7 +227,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_ONE_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
 
-    Annotation a = tsdb.getAnnotation(TSUID_GLOBAL_ANNOTATION, 1328140802)
+    Annotation a = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, 1328140802)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     assertEquals("Boo",a.getDescription());
   }
@@ -256,8 +256,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
 
-    Annotation local = tsdb.
-            getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    Annotation local = tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(local);
 
@@ -280,8 +279,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation global = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation global = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global);
 
@@ -303,8 +301,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
-    Annotation local = tsdb.
-            getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    Annotation local = tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(local);
 
@@ -327,8 +324,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation global = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation global = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global);
 
@@ -353,8 +349,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
 
-    Annotation local = tsdb.
-            getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    Annotation local = tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(local);
     assertEquals("Boo", local.getDescription());
@@ -377,8 +372,7 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation global = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation global = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global);
     assertEquals("Boo",global.getDescription());
@@ -407,7 +401,7 @@ public final class TestAnnotationRpc {
     //check right resonse
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     //check that tsuid is gone
-    assertNull(tsdb.getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    assertNull(tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
     //verify others
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
@@ -425,7 +419,7 @@ public final class TestAnnotationRpc {
     //check right resonse
     assertEquals(HttpResponseStatus.NO_CONTENT, query.response().getStatus());
     //check that tsuid is gone
-    assertNull(tsdb.getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    assertNull(tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
     //verify others
     isUnchanged(TSUID_ANNOTATION, LOCAL_ONE_START_TIME);
@@ -478,14 +472,12 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation local = tsdb.
-            getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    Annotation local = tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(local);
     assertEquals("Boo", local.getDescription());
 
-    Annotation new_local = tsdb.
-            getAnnotation("000001000001000002", LOCAL_ONE_START_TIME)
+    Annotation new_local = tsdb.getMetaClient().getAnnotation("000001000001000002", LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(new_local);
     assertEquals("Gum", new_local.getDescription());
@@ -508,14 +500,12 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation global = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation global = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global);
     assertEquals("Boo", global.getDescription());
 
-    Annotation new_local = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, LOCAL_ONE_START_TIME)
+    Annotation new_local = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(new_local);
     assertEquals("Gum", new_local.getDescription());
@@ -548,14 +538,12 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME);
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME);
 
-    Annotation local = tsdb.
-            getAnnotation(TSUID_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation local = tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(local);
     assertEquals("Boo", local.getDescription());
 
-    Annotation new_local = tsdb.
-            getAnnotation("000001000001000002", GLOBAL_ONE_START_TIME)
+    Annotation new_local = tsdb.getMetaClient().getAnnotation("000001000001000002", GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(new_local);
     assertEquals("Gum", new_local.getDescription());
@@ -578,14 +566,12 @@ public final class TestAnnotationRpc {
     isUnchanged(TSUID_ANNOTATION, LOCAL_ONE_START_TIME);
     isUnchanged(TSUID_ANNOTATION, LOCAL_TWO_START_TIME);
 
-    Annotation global = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
+    Annotation global = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global);
     assertEquals("Boo", global.getDescription());
 
-    Annotation global2 = tsdb.
-            getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME)
+    Annotation global2 = tsdb.getMetaClient().getAnnotation(TSUID_GLOBAL_ANNOTATION, GLOBAL_TWO_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(global2);
     assertEquals("Gum", global2.getDescription());
@@ -602,7 +588,7 @@ public final class TestAnnotationRpc {
       .toString(Charset.forName("UTF-8"));
     assertTrue(data.contains("\"totalDeleted\":1"));
 
-    assertNull(tsdb.getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    assertNull(tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
       .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME);
@@ -639,10 +625,10 @@ public final class TestAnnotationRpc {
       .toString(Charset.forName("UTF-8"));
     assertTrue(data.contains("\"totalDeleted\":2"));
 
-    assertNull(tsdb.getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
+    assertNull(tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_ONE_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
-    assertNull(tsdb.getAnnotation(TSUID_ANNOTATION, LOCAL_TWO_START_TIME)
+    assertNull(tsdb.getMetaClient().getAnnotation(TSUID_ANNOTATION, LOCAL_TWO_START_TIME)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT));
 
     isUnchanged(TSUID_GLOBAL_ANNOTATION, GLOBAL_ONE_START_TIME);
@@ -788,8 +774,7 @@ public final class TestAnnotationRpc {
     String tsuid = TSUID;
     if (null == TSUID) tsuid = "";
 
-    Annotation a = tsdb.
-            getAnnotation(TSUID, timestamp)
+    Annotation a = tsdb.getMetaClient().getAnnotation(TSUID, timestamp)
             .joinUninterruptibly(MockBase.DEFAULT_TIMEOUT);
     checkNotNull(a);
     Annotation original = annotations.get(tsuid, timestamp);


### PR DESCRIPTION
This leaves out the methods `#indexAnnotation` and `#deleteAnnotation` but moving these requires a lot of fiddling around with the plugins which I would rather do in a standalone PR.