### PR TITLE
Remove the ability to load JARs after startup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,6 @@ package = net.opentsdb
 spec_title = OpenTSDB
 spec_vendor = The OpenTSDB Authors
 jar := tsdb-$(PACKAGE_VERSION).jar
-plugin_test_jar := plugin_test.jar
 builddata_SRC := src/BuildData.java
 BUILT_SOURCES = $(builddata_SRC)
 nodist_bin_SCRIPTS = tsdb
@@ -30,102 +29,134 @@ dist_noinst_SCRIPTS = src/create_table.sh src/upgrade_1to2.sh src/mygnuplot.sh \
 dist_noinst_DATA = pom.xml.in build-aux/rpm/opentsdb.conf \
   build-aux/rpm/logback.xml build-aux/rpm/init.d/opentsdb
 tsdb_SRC := \
-	src/core/AggregationIterator.java	\
-	src/core/Aggregator.java	\
-	src/core/Aggregators.java	\
-	src/core/ByteBufferList.java	\
-	src/core/ColumnDatapointIterator.java	\
-	src/core/CompactionQueue.java	\
-	src/core/Const.java	\
-	src/core/DataPoint.java	\
-	src/core/DataPoints.java	\
-	src/core/DataPointsIterator.java	\
+	src/core/AggregationIterator.java \
+	src/core/Aggregator.java \
+	src/core/Aggregators.java \
+	src/core/Const.java \
+	src/core/DataPoint.java \
+	src/core/DataPointsIterator.java \
+	src/core/DataPoints.java \
+	src/core/DefaultRealtimePublisher.java \
+	src/core/DefaultSearchPlugin.java \
 	src/core/Downsampler.java \
-	src/core/IncomingDataPoint.java	\
-	src/core/IncomingDataPoints.java	\
-	src/core/IllegalDataException.java	\
-	src/core/Internal.java	\
+	src/core/IllegalDataException.java \
+	src/core/IncomingDataPoint.java \
+	src/core/IncomingDataPoints.java \
+	src/core/Internal.java \
+	src/core/MetaClient.java \
 	src/core/MutableDataPoint.java \
-	src/core/Query.java	\
-	src/core/RateOptions.java  \
-	src/core/RateSpan.java  \
-	src/core/RowKey.java	\
-	src/core/RowSeq.java	\
-	src/core/SeekableView.java	\
-	src/core/Span.java	\
-	src/core/SpanGroup.java	\
+	src/core/QueryBuilder.java \
+	src/core/Query.java \
+	src/core/RateOptions.java \
+	src/core/RateSpan.java \
+	src/core/RowKey.java \
+	src/core/SeekableView.java \
+	src/core/SpanGroup.java \
+	src/core/Span.java \
 	src/core/StringCoder.java \
-	src/core/TSDB.java	\
-	src/core/Tags.java	\
-	src/core/TsdbQuery.java	\
-	src/core/TSQuery.java	\
-	src/core/TSSubQuery.java	\
-	src/core/WritableDataPoints.java	\
-	src/graph/Plot.java	\
-	src/meta/Annotation.java	\
-	src/meta/TSMeta.java	\
-	src/meta/TSUIDQuery.java	\
-	src/meta/UIDMeta.java	\
-	src/search/SearchPlugin.java	\
-	src/search/SearchQuery.java	\
-	src/search/TimeSeriesLookup.java	\
-	src/stats/Histogram.java	\
-	src/stats/StatsCollector.java	\
+	src/core/Tags.java \
+	src/core/Timestamp.java \
+	src/core/TsdbBuilder.java \
+	src/core/TSDB.java \
+	src/core/TSQuery.java \
+	src/core/TSSubQuery.java \
+	src/core/UniqueIdClient.java \
+	src/core/WritableDataPoints.java \
+	src/graph/Plot.java \
+	src/meta/Annotation.java \
+	src/meta/TSMeta.java \
+	src/meta/TSUIDQuery.java \
+	src/meta/UIDMeta.java \
+	src/search/SearchPlugin.java \
+	src/search/SearchQuery.java \
+	src/search/TimeSeriesLookup.java \
+	src/stats/Histogram.java \
+	src/stats/StatsCollector.java \
+	src/storage/hbase/ByteBufferList.java \
+	src/storage/hbase/ColumnDatapointIterator.java \
+	src/storage/hbase/CompactedRow.java \
+	src/storage/hbase/CompactionQueue.java \
+	src/storage/hbase/HBaseConst.java \
+	src/storage/hbase/HBaseStoreDescriptor.java \
+	src/storage/hbase/HBaseStore.java \
+	src/storage/hbase/QueryRunner.java \
+	src/storage/hbase/SpanCmp.java \
+	src/storage/json/AnnotationMixIn.java \
+	src/storage/json/BranchMixIn.java \
+	src/storage/json/LeafMixIn.java \
+	src/storage/json/StorageModule.java \
+	src/storage/json/TreeMixIn.java \
+	src/storage/json/TreeRuleMixIn.java \
+	src/storage/json/TreeRuleTypeDeserializer.java \
+	src/storage/json/TSMetaMixIn.java \
+	src/storage/json/UIDMetaMixIn.java \
+	src/storage/json/UniqueIdTypeDeserializer.java \
+	src/storage/StoreDescriptor.java \
+	src/storage/StoreSupplier.java \
 	src/storage/TsdbStore.java \
-	src/storage/HBaseStore.java \
-	src/tools/ArgP.java	\
-	src/tools/CliOptions.java	\
-	src/tools/CliQuery.java	\
-	src/tools/CliUtils.java	\
-	src/tools/DumpSeries.java	\
-	src/tools/Fsck.java	\
-	src/tools/FsckOptions.java	\
-	src/tools/MetaPurge.java	\
-	src/tools/MetaSync.java	\
-	src/tools/Search.java	\
-	src/tools/TSDMain.java	\
-	src/tools/TextImporter.java	\
-	src/tools/TreeSync.java	\
-	src/tools/UidManager.java	\
-	src/tree/Branch.java	\
-	src/tree/Leaf.java	\
-	src/tree/Tree.java	\
-	src/tree/TreeBuilder.java	\
-	src/tree/TreeRule.java	\
-	src/tsd/AnnotationRpc.java	\
-	src/tsd/BadRequestException.java	\
-	src/tsd/ConnectionManager.java	\
-	src/tsd/GnuplotException.java	\
-	src/tsd/GraphHandler.java	\
-	src/tsd/HttpJsonSerializer.java	\
-	src/tsd/HttpSerializer.java	\
-	src/tsd/HttpQuery.java	\
-	src/tsd/HttpRpc.java	\
-	src/tsd/LineBasedFrameDecoder.java	\
-	src/tsd/LogsRpc.java	\
-	src/tsd/PipelineFactory.java	\
-	src/tsd/PutDataPointRpc.java	\
-	src/tsd/QueryRpc.java	\
-	src/tsd/RpcHandler.java	\
-	src/tsd/RTPublisher.java	\
-	src/tsd/SearchRpc.java	\
-	src/tsd/StaticFileRpc.java	\
-	src/tsd/StatsRpc.java	\
-	src/tsd/SuggestRpc.java	\
-	src/tsd/TelnetRpc.java	\
-	src/tsd/TreeRpc.java	\
-	src/tsd/UniqueIdRpc.java	\
-	src/tsd/WordSplitter.java	\
-	src/uid/NoSuchUniqueId.java	\
-	src/uid/NoSuchUniqueName.java	\
-	src/uid/UniqueId.java	\
-	src/uid/UniqueIdInterface.java \
+	src/tools/ArgP.java \
+	src/tools/CliOptions.java \
+	src/tools/CliQuery.java \
+	src/tools/CliUtils.java \
+	src/tools/DumpSeries.java \
+	src/tools/Fsck.java \
+	src/tools/FsckOptions.java \
+	src/tools/MetaPurge.java \
+	src/tools/MetaSync.java \
+	src/tools/Search.java \
+	src/tools/TextImporter.java \
+	src/tools/TreeSync.java \
+	src/tools/TSDMain.java \
+	src/tools/UidManager.java \
+	src/tree/Branch.java \
+	src/tree/Leaf.java \
+	src/tree/TreeBuilder.java \
+	src/tree/Tree.java \
+	src/tree/TreeRule.java \
+	src/tsd/AnnotationRpc.java \
+	src/tsd/BadRequestException.java \
+	src/tsd/client/DateTimeBox.java \
+	src/tsd/client/EventsHandler.java \
+	src/tsd/client/GotJsonCallback.java \
+	src/tsd/client/MetricForm.java \
+	src/tsd/client/QueryString.java \
+	src/tsd/client/QueryUi.java \
+	src/tsd/client/RemoteOracle.java \
+	src/tsd/client/ValidatedTextBox.java \
+	src/tsd/ConnectionManager.java \
+	src/tsd/GnuplotException.java \
+	src/tsd/GraphHandler.java \
+	src/tsd/HttpJsonSerializer.java \
+	src/tsd/HttpQuery.java \
+	src/tsd/HttpRpc.java \
+	src/tsd/HttpSerializer.java \
+	src/tsd/LineBasedFrameDecoder.java \
+	src/tsd/LogsRpc.java \
+	src/tsd/PipelineFactory.java \
+	src/tsd/PutDataPointRpc.java \
+	src/tsd/QueryRpc.java \
+	src/tsd/RpcHandler.java \
+	src/tsd/RTPublisher.java \
+	src/tsd/SearchRpc.java \
+	src/tsd/StaticFileRpc.java \
+	src/tsd/StatsRpc.java \
+	src/tsd/SuggestRpc.java \
+	src/tsd/TelnetRpc.java \
+	src/tsd/TreeRpc.java \
+	src/tsd/UniqueIdRpc.java \
+	src/tsd/WordSplitter.java \
+	src/uid/NoSuchUniqueId.java \
+	src/uid/NoSuchUniqueName.java \
+	src/uid/UidFormatter.java \
+	src/uid/UidResolver.java \
+	src/uid/UniqueId.java \
+	src/uid/UniqueIdType.java \
 	src/utils/ByteArrayPair.java \
 	src/utils/Config.java \
 	src/utils/DateTime.java \
+	src/utils/JSONException.java \
 	src/utils/JSON.java \
-	src/utils/JSONException.java	\
-	src/utils/Pair.java	\
+	src/utils/Pair.java \
 	src/utils/PluginLoader.java
 
 tsdb_DEPS = \
@@ -144,80 +175,86 @@ tsdb_DEPS = \
 	$(ZOOKEEPER)
 
 test_SRC := \
-	test/core/SeekableViewsForTest.java \
-	test/core/TestAggregationIterator.java \
-	test/core/TestAggregators.java \
-	test/core/TestCompactionQueue.java	\
-	test/core/TestDownsampler.java \
-	test/core/TestInternal.java	\
-	test/core/TestMutableDataPoint.java	\
-	test/core/TestRateSpan.java	\
-	test/core/TestRowSeq.java	\
-	test/core/TestSpan.java	\
-	test/core/TestTags.java	\
-	test/core/TestTSDB.java	\
-	test/core/TestTsdbQueryDownsample.java	\
-	test/core/TestTsdbQuery.java	\
-	test/core/TestTSQuery.java	\
-	test/core/TestTSSubQuery.java	\
-	test/plugin/DummyPlugin.java \
-	test/meta/TestAnnotation.java	\
-	test/meta/TestTSMeta.java	\
-	test/meta/TestTSUIDQuery.java	\
-	test/meta/TestUIDMeta.java	\
-	test/search/TestSearchPlugin.java	\
-	test/search/TestSearchQuery.java	\
-	test/search/TestTimeSeriesLookup.java	\
-	test/stats/TestHistogram.java	\
-	test/storage/MemoryStore.java \
-	test/storage/MockBase.java	\
-	test/tools/TestDumpSeries.java	\
-	test/tools/TestFsck.java	\
-	test/tools/TestTextImporter.java	\
-	test/tools/TestUID.java	\
-	test/tree/TestBranch.java	\
-	test/tree/TestLeaf.java	\
-	test/tree/TestTree.java	\
-	test/tree/TestTreeBuilder.java	\
-	test/tree/TestTreeRule.java	\
-	test/tsd/NettyMocks.java	\
-	test/tsd/TestAnnotationRpc.java	\
-	test/tsd/TestGraphHandler.java	\
-	test/tsd/TestHttpJsonSerializer.java	\
-	test/tsd/TestHttpQuery.java	\
-	test/tsd/TestPutRpc.java	\
-	test/tsd/TestQueryRpc.java	\
-	test/tsd/TestRpcHandler.java	\
-	test/tsd/TestRTPublisher.java	\
-	test/tsd/TestSearchRpc.java	\
-	test/tsd/TestSuggestRpc.java	\
-	test/tsd/TestTreeRpc.java	\
-	test/tsd/TestUniqueIdRpc.java	\
-	test/uid/TestNoSuchUniqueId.java	\
-	test/uid/TestUniqueId.java \
-	test/utils/TestByteArrayPair.java \
-	test/utils/TestConfig.java \
-	test/utils/TestDateTime.java \
-	test/utils/TestJSON.java \
-	test/utils/TestPair.java \
-	test/utils/TestPluginLoader.java
-	
-test_plugin_SRC := \
+  test/core/MetaClientAnnotationTest.java \
+  test/core/RowKeyTest.java \
+  test/core/SeekableViewsForTest.java \
+  test/core/TestAggregationIterator.java \
+  test/core/TestAggregators.java \
+  test/core/TestDownsampler.java \
+  test/core/TestInternal.java \
+  test/core/TestMutableDataPoint.java \
+  test/core/TestQueryBuilder.java \
+  test/core/TestRateSpan.java \
+  test/core/TestSpan.java \
+  test/core/TestTags.java \
+  test/core/TestTSDBExecuteQuery.java \
+  test/core/TestTSDB.java \
+  test/core/TestTsdbQueryDownsample.java \
+  test/core/TestTSQuery.java \
+  test/core/TestTSSubQuery.java \
+  test/core/TsdbBuilderTest.java \
+  test/core/UniqueIdClientTest.java \
+  test/meta/TestTSMeta.java \
+  test/meta/TestTSUIDQuery.java \
+  test/meta/TestUIDMeta.java \
   test/plugin/DummyPluginA.java \
   test/plugin/DummyPluginB.java \
+  test/plugin/DummyPlugin.java \
   test/search/DummySearchPlugin.java \
+  test/search/TestSearchPlugin.java \
+  test/search/TestSearchQuery.java \
+  test/search/TestTimeSeriesLookup.java \
+  test/stats/TestHistogram.java \
+  test/storage/hbase/TestCompactedRow.java \
+  test/storage/hbase/TestCompactionQueue.java \
+  test/storage/hbase/TestHBaseStore.java \
+  test/storage/json/AnnotationMixInTest.java \
+  test/storage/json/BranchMixInTest.java \
+  test/storage/json/LeafMixInTest.java \
+  test/storage/json/TreeMixInTest.java \
+  test/storage/json/TreeRuleMixInTest.java \
+  test/storage/json/TSMetaMixInTest.java \
+  test/storage/json/UIDMetaMixInTest.java \
+  test/storage/MemoryStore.java \
+  test/storage/MockBase.java \
+  test/storage/StoreSupplierTest.java \
+  test/storage/TestMemoryStore.java \
+  test/storage/TestTsdbStore.java \
+  test/tools/TestDumpSeries.java \
+  test/tools/TestFsck.java \
+  test/tools/TestTextImporter.java \
+  test/tools/TestUID.java \
+  test/tree/TestBranch.java \
+  test/tree/TestLeaf.java \
+  test/tree/TestTreeBuilder.java \
+  test/tree/TestTree.java \
+  test/tree/TestTreeRule.java \
   test/tsd/DummyHttpSerializer.java \
-  test/tsd/DummyRTPublisher.java
-
-# Do NOT include the test dir path, just the META portion
-test_plugin_SVCS := \
-  META-INF/services/net.opentsdb.plugin.DummyPlugin \
-  META-INF/services/net.opentsdb.search.SearchPlugin \
-  META-INF/services/net.opentsdb.tsd.HttpSerializer \
-  META-INF/services/net.opentsdb.tsd.RTPublisher
-  
-test_plugin_MF := \
-  test/META-INF/MANIFEST.MF
+  test/tsd/DummyRTPublisher.java \
+  test/tsd/NettyMocks.java \
+  test/tsd/RpcJSONUtils.java \
+  test/tsd/TestAnnotationRpc.java \
+  test/tsd/TestGraphHandler.java \
+  test/tsd/TestHttpJsonSerializer.java \
+  test/tsd/TestHttpQuery.java \
+  test/tsd/TestPutRpc.java \
+  test/tsd/TestQueryRpc.java \
+  test/tsd/TestRpcHandler.java \
+  test/tsd/TestRTPublisher.java \
+  test/tsd/TestSearchRpc.java \
+  test/tsd/TestSuggestRpc.java \
+  test/tsd/TestTreeRpc.java \
+  test/tsd/TestUniqueIdRpc.java \
+  test/uid/TestNoSuchUniqueId.java \
+  test/uid/TestUidFormatter.java \
+  test/uid/TestUidResolver.java \
+  test/uid/TestUniqueId.java \
+  test/utils/TestByteArrayPair.java \
+  test/utils/TestConfig.java \
+  test/utils/TestDateTime.java \
+  test/utils/TestJSON.java \
+  test/utils/TestPair.java \
+  test/utils/TestPluginLoader.java
 
 test_DEPS = \
 	$(tsdb_DEPS) \
@@ -245,7 +282,6 @@ httpui_DEPS = src/tsd/QueryUi.gwt.xml
 dist_static_DATA = src/tsd/static/favicon.ico
 
 EXTRA_DIST = tsdb.in $(tsdb_SRC) $(test_SRC) \
-        $(test_plugin_SRC) $(test_plugin_MF) $(test_plugin_SVCS:%=test/%) \
         $(THIRD_PARTY) $(THIRD_PARTY:=.md5) \
         $(httpui_SRC) $(httpui_DEPS) \
 	tools/check_tsd	\
@@ -260,8 +296,6 @@ GWTC_ARGS = -ea -strict  # Additional arguments like -style PRETTY or -logLevel 
 
 package_dir := $(subst .,/,$(package))
 UNITTESTS := $(test_SRC:test/%.java=$(package_dir)/%.class)
-PLUGINTESTS := $(test_plugin_SRC:test/%.java=$(package_dir)/%.class)
-PLUGINSVCS := $(test_plugin_SVCS:%=-C $(srcdir)/test %)
 AM_JAVACFLAGS = -Xlint -source 6 -encoding utf-8
 JVM_ARGS =
 classes := $(tsdb_SRC:src/%.java=$(package_dir)/%.class) \
@@ -494,17 +528,6 @@ uninstall-hook:
 get_runtime_dep_classpath = `for jar in $(test_DEPS); do $(find_jar); done | tr '\n' ':'`
 $(test_SRC): $(test_DEPS)
 	@$(refresh_src)
-	
-$(test_plugin_SRC): $(test_DEPS)
-	@$(refresh_src)
-
-# compile the plugin unittest jar before the unittests
-.javac-unittests-plugin-stamp: $(jar) $(test_plugin_SRC)
-	@$(filter_src); cp=$(get_runtime_dep_classpath); \
-          echo "$(JAVA_COMPILE) -cp $$cp $$src"; \
-                $(JAVA_COMPILE) -cp $$cp $$src
-	@touch "$@"
-	@touch .javac-unittests-plugin-stamp
 
 .javac-unittests-stamp: $(jar) $(test_SRC)
 	@$(filter_src); cp=$(get_runtime_dep_classpath); \
@@ -515,11 +538,10 @@ $(test_plugin_SRC): $(test_DEPS)
 
 classes_with_nested_classes := $(classes:.class=*.class)
 test_classes_with_nested_classes := $(UNITTESTS:.class=*.class)
-test_plugin_classes := $(PLUGINTESTS:.class=*.class)
 
 # Little set script to make a pretty-ish banner.
 BANNER := sed 's/^.*/  &  /;h;s/./=/g;p;x;p;x'
-check-local: .javac-unittests-stamp .javac-unittests-plugin-stamp $(plugin_test_jar)
+check-local: .javac-unittests-stamp
 	classes=`echo $(test_classes_with_nested_classes)` \
         && tests=0 && failures=0 \
         && cp="$(get_runtime_dep_classpath):$(srcdir)/src" && \
@@ -552,9 +574,6 @@ $(jar): manifest .javac-stamp $(classes)
 #                       ^^^^^^^^^^^^^^^^^^^^^^^
 # I've seen cases where `jar' exits with an error but leaves a partially built .jar file!
 
-$(plugin_test_jar): .javac-unittests-plugin-stamp
-	$(JAR) cvfm $(plugin_test_jar) $(srcdir)/$(test_plugin_MF) $(test_plugin_classes) $(PLUGINSVCS)
-
 # Generate the file for those who get a tarball without it.  This happens if
 # you download a tarball off GitHub for instance.
 .git/HEAD:
@@ -576,10 +595,10 @@ dist-hook:
 	echo $(git_version) >$(distdir)/.git/HEAD
 
 mostlyclean-local:
-	@rm -f .javac-stamp .javac-unittests-stamp .javac-unittests-plugin-stamp .gwtc-stamp* .staticroot-stamp
+	@rm -f .javac-stamp .javac-unittests-stamp .gwtc-stamp* .staticroot-stamp
 	rm -rf gwt gwt-unitCache staticroot
 	rm -f manifest $(BUILT_SOURCES)
-	rm -f $(classes_with_nested_classes) $(test_classes_with_nested_classes) $(test_plugin_classes)
+	rm -f $(classes_with_nested_classes) $(test_classes_with_nested_classes)
 	test -d $(package_dir) || exit 0 \
 	  && find $(package_dir) -depth -type d -exec rmdir {} ';' \
 	  && dir=$(package_dir) && dir=$${dir%/*} \
@@ -589,7 +608,7 @@ mostlyclean-local:
 	  && rmdir "$$dir"
 
 clean-local:
-	rm -f $(jar) $(plugin_test_jar) tsdb $(srcdir)/pom.xml
+	rm -f $(jar) tsdb $(srcdir)/pom.xml
 	rm -rf $(JAVADOC_DIR)
 
 distclean-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,8 +34,8 @@ tsdb_SRC := \
 	src/core/Aggregators.java \
 	src/core/Const.java \
 	src/core/DataPoint.java \
-	src/core/DataPointsIterator.java \
 	src/core/DataPoints.java \
+	src/core/DataPointsIterator.java \
 	src/core/DefaultRealtimePublisher.java \
 	src/core/DefaultSearchPlugin.java \
 	src/core/Downsampler.java \
@@ -45,19 +45,19 @@ tsdb_SRC := \
 	src/core/Internal.java \
 	src/core/MetaClient.java \
 	src/core/MutableDataPoint.java \
-	src/core/QueryBuilder.java \
 	src/core/Query.java \
+	src/core/QueryBuilder.java \
 	src/core/RateOptions.java \
 	src/core/RateSpan.java \
 	src/core/RowKey.java \
 	src/core/SeekableView.java \
-	src/core/SpanGroup.java \
 	src/core/Span.java \
+	src/core/SpanGroup.java \
 	src/core/StringCoder.java \
 	src/core/Tags.java \
 	src/core/Timestamp.java \
-	src/core/TsdbBuilder.java \
 	src/core/TSDB.java \
+	src/core/TsdbBuilder.java \
 	src/core/TSQuery.java \
 	src/core/TSSubQuery.java \
 	src/core/UniqueIdClient.java \
@@ -77,8 +77,8 @@ tsdb_SRC := \
 	src/storage/hbase/CompactedRow.java \
 	src/storage/hbase/CompactionQueue.java \
 	src/storage/hbase/HBaseConst.java \
-	src/storage/hbase/HBaseStoreDescriptor.java \
 	src/storage/hbase/HBaseStore.java \
+	src/storage/hbase/HBaseStoreDescriptor.java \
 	src/storage/hbase/QueryRunner.java \
 	src/storage/hbase/SpanCmp.java \
 	src/storage/json/AnnotationMixIn.java \
@@ -110,8 +110,8 @@ tsdb_SRC := \
 	src/tools/UidManager.java \
 	src/tree/Branch.java \
 	src/tree/Leaf.java \
-	src/tree/TreeBuilder.java \
 	src/tree/Tree.java \
+	src/tree/TreeBuilder.java \
 	src/tree/TreeRule.java \
 	src/tsd/AnnotationRpc.java \
 	src/tsd/BadRequestException.java \
@@ -154,8 +154,8 @@ tsdb_SRC := \
 	src/utils/ByteArrayPair.java \
 	src/utils/Config.java \
 	src/utils/DateTime.java \
-	src/utils/JSONException.java \
 	src/utils/JSON.java \
+	src/utils/JSONException.java \
 	src/utils/Pair.java \
 	src/utils/PluginLoader.java
 
@@ -175,86 +175,86 @@ tsdb_DEPS = \
 	$(ZOOKEEPER)
 
 test_SRC := \
-  test/core/MetaClientAnnotationTest.java \
-  test/core/RowKeyTest.java \
-  test/core/SeekableViewsForTest.java \
-  test/core/TestAggregationIterator.java \
-  test/core/TestAggregators.java \
-  test/core/TestDownsampler.java \
-  test/core/TestInternal.java \
-  test/core/TestMutableDataPoint.java \
-  test/core/TestQueryBuilder.java \
-  test/core/TestRateSpan.java \
-  test/core/TestSpan.java \
-  test/core/TestTags.java \
-  test/core/TestTSDBExecuteQuery.java \
-  test/core/TestTSDB.java \
-  test/core/TestTsdbQueryDownsample.java \
-  test/core/TestTSQuery.java \
-  test/core/TestTSSubQuery.java \
-  test/core/TsdbBuilderTest.java \
-  test/core/UniqueIdClientTest.java \
-  test/meta/TestTSMeta.java \
-  test/meta/TestTSUIDQuery.java \
-  test/meta/TestUIDMeta.java \
-  test/plugin/DummyPluginA.java \
-  test/plugin/DummyPluginB.java \
-  test/plugin/DummyPlugin.java \
-  test/search/DummySearchPlugin.java \
-  test/search/TestSearchPlugin.java \
-  test/search/TestSearchQuery.java \
-  test/search/TestTimeSeriesLookup.java \
-  test/stats/TestHistogram.java \
-  test/storage/hbase/TestCompactedRow.java \
-  test/storage/hbase/TestCompactionQueue.java \
-  test/storage/hbase/TestHBaseStore.java \
-  test/storage/json/AnnotationMixInTest.java \
-  test/storage/json/BranchMixInTest.java \
-  test/storage/json/LeafMixInTest.java \
-  test/storage/json/TreeMixInTest.java \
-  test/storage/json/TreeRuleMixInTest.java \
-  test/storage/json/TSMetaMixInTest.java \
-  test/storage/json/UIDMetaMixInTest.java \
-  test/storage/MemoryStore.java \
-  test/storage/MockBase.java \
-  test/storage/StoreSupplierTest.java \
-  test/storage/TestMemoryStore.java \
-  test/storage/TestTsdbStore.java \
-  test/tools/TestDumpSeries.java \
-  test/tools/TestFsck.java \
-  test/tools/TestTextImporter.java \
-  test/tools/TestUID.java \
-  test/tree/TestBranch.java \
-  test/tree/TestLeaf.java \
-  test/tree/TestTreeBuilder.java \
-  test/tree/TestTree.java \
-  test/tree/TestTreeRule.java \
-  test/tsd/DummyHttpSerializer.java \
-  test/tsd/DummyRTPublisher.java \
-  test/tsd/NettyMocks.java \
-  test/tsd/RpcJSONUtils.java \
-  test/tsd/TestAnnotationRpc.java \
-  test/tsd/TestGraphHandler.java \
-  test/tsd/TestHttpJsonSerializer.java \
-  test/tsd/TestHttpQuery.java \
-  test/tsd/TestPutRpc.java \
-  test/tsd/TestQueryRpc.java \
-  test/tsd/TestRpcHandler.java \
-  test/tsd/TestRTPublisher.java \
-  test/tsd/TestSearchRpc.java \
-  test/tsd/TestSuggestRpc.java \
-  test/tsd/TestTreeRpc.java \
-  test/tsd/TestUniqueIdRpc.java \
-  test/uid/TestNoSuchUniqueId.java \
-  test/uid/TestUidFormatter.java \
-  test/uid/TestUidResolver.java \
-  test/uid/TestUniqueId.java \
-  test/utils/TestByteArrayPair.java \
-  test/utils/TestConfig.java \
-  test/utils/TestDateTime.java \
-  test/utils/TestJSON.java \
-  test/utils/TestPair.java \
-  test/utils/TestPluginLoader.java
+	test/core/MetaClientAnnotationTest.java \
+	test/core/RowKeyTest.java \
+	test/core/SeekableViewsForTest.java \
+	test/core/TestAggregationIterator.java \
+	test/core/TestAggregators.java \
+	test/core/TestDownsampler.java \
+	test/core/TestInternal.java \
+	test/core/TestMutableDataPoint.java \
+	test/core/TestQueryBuilder.java \
+	test/core/TestRateSpan.java \
+	test/core/TestSpan.java \
+	test/core/TestTags.java \
+	test/core/TestTSDB.java \
+	test/core/TestTSDBExecuteQuery.java \
+	test/core/TestTsdbQueryDownsample.java \
+	test/core/TestTSQuery.java \
+	test/core/TestTSSubQuery.java \
+	test/core/TsdbBuilderTest.java \
+	test/core/UniqueIdClientTest.java \
+	test/meta/TestTSMeta.java \
+	test/meta/TestTSUIDQuery.java \
+	test/meta/TestUIDMeta.java \
+	test/plugin/DummyPlugin.java \
+	test/plugin/DummyPluginA.java \
+	test/plugin/DummyPluginB.java \
+	test/search/DummySearchPlugin.java \
+	test/search/TestSearchPlugin.java \
+	test/search/TestSearchQuery.java \
+	test/search/TestTimeSeriesLookup.java \
+	test/stats/TestHistogram.java \
+	test/storage/hbase/TestCompactedRow.java \
+	test/storage/hbase/TestCompactionQueue.java \
+	test/storage/hbase/TestHBaseStore.java \
+	test/storage/json/AnnotationMixInTest.java \
+	test/storage/json/BranchMixInTest.java \
+	test/storage/json/LeafMixInTest.java \
+	test/storage/json/TreeMixInTest.java \
+	test/storage/json/TreeRuleMixInTest.java \
+	test/storage/json/TSMetaMixInTest.java \
+	test/storage/json/UIDMetaMixInTest.java \
+	test/storage/MemoryStore.java \
+	test/storage/MockBase.java \
+	test/storage/StoreSupplierTest.java \
+	test/storage/TestMemoryStore.java \
+	test/storage/TestTsdbStore.java \
+	test/tools/TestDumpSeries.java \
+	test/tools/TestFsck.java \
+	test/tools/TestTextImporter.java \
+	test/tools/TestUID.java \
+	test/tree/TestBranch.java \
+	test/tree/TestLeaf.java \
+	test/tree/TestTree.java \
+	test/tree/TestTreeBuilder.java \
+	test/tree/TestTreeRule.java \
+	test/tsd/DummyHttpSerializer.java \
+	test/tsd/DummyRTPublisher.java \
+	test/tsd/NettyMocks.java \
+	test/tsd/RpcJSONUtils.java \
+	test/tsd/TestAnnotationRpc.java \
+	test/tsd/TestGraphHandler.java \
+	test/tsd/TestHttpJsonSerializer.java \
+	test/tsd/TestHttpQuery.java \
+	test/tsd/TestPutRpc.java \
+	test/tsd/TestQueryRpc.java \
+	test/tsd/TestRpcHandler.java \
+	test/tsd/TestRTPublisher.java \
+	test/tsd/TestSearchRpc.java \
+	test/tsd/TestSuggestRpc.java \
+	test/tsd/TestTreeRpc.java \
+	test/tsd/TestUniqueIdRpc.java \
+	test/uid/TestNoSuchUniqueId.java \
+	test/uid/TestUidFormatter.java \
+	test/uid/TestUidResolver.java \
+	test/uid/TestUniqueId.java \
+	test/utils/TestByteArrayPair.java \
+	test/utils/TestConfig.java \
+	test/utils/TestDateTime.java \
+	test/utils/TestJSON.java \
+	test/utils/TestPair.java \
+	test/utils/TestPluginLoader.java
 
 test_DEPS = \
 	$(tsdb_DEPS) \

--- a/pom.xml.in
+++ b/pom.xml.in
@@ -103,49 +103,6 @@
               <goal>exec</goal>
             </goals>
           </execution>
-          <execution>
-            <id>create-plugin-test-jar</id>
-            <!-- TODO: Put the jar in the target dir and fix surefire conf. -->
-            <configuration>
-              <executable>jar</executable>
-              <arguments>
-                <argument>cvfm</argument>
-                <argument>plugin_test.jar</argument>
-                <argument>test/META-INF/MANIFEST.MF</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/plugin/DummyPluginA.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/plugin/DummyPluginB.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/search/DummySearchPlugin.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/tsd/DummyHttpSerializer.class</argument>
-                <argument>-C</argument>
-                <argument>target/test-classes</argument>
-                <argument>net/opentsdb/tsd/DummyRTPublisher.class</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.plugin.DummyPlugin</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.search.SearchPlugin</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.tsd.HttpSerializer</argument>
-                <argument>-C</argument>
-                <argument>test</argument>
-                <argument>META-INF/services/net.opentsdb.tsd.RTPublisher</argument>
-              </arguments>
-            </configuration>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
         </executions>
       </plugin>
 

--- a/src/core/TsdbBuilder.java
+++ b/src/core/TsdbBuilder.java
@@ -9,7 +9,6 @@ import net.opentsdb.utils.Config;
 import net.opentsdb.utils.PluginLoader;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.slf4j.Logger;
@@ -38,8 +37,6 @@ public class TsdbBuilder {
   public static TsdbBuilder createFromConfig(final Config config) {
     checkNotNull(config);
 
-    addPluginPath(config);
-
     TsdbBuilder builder = new TsdbBuilder();
 
     StoreSupplier storeSupplier = new StoreSupplier(config,
@@ -51,24 +48,6 @@ public class TsdbBuilder {
             .withRealtimePublisher(loadRealtimePublisher(config));
 
     return builder;
-  }
-
-  /**
-   * Add the plugin path that is read from the config to the class path.
-   * @param config The config object to read from
-   */
-  private static void addPluginPath(final Config config) {
-    final String plugin_path = config.getString("tsd.core.plugin_path");
-
-    if (!Strings.isNullOrEmpty(plugin_path)) {
-      try {
-        PluginLoader.loadJARs(plugin_path);
-      } catch (Exception e) {
-        LOG.error("Error loading plugins from plugin path: {}", plugin_path, e);
-        throw new RuntimeException("Error loading plugins from plugin path: " +
-                plugin_path, e);
-      }
-    }
   }
 
   /**

--- a/src/utils/Config.java
+++ b/src/utils/Config.java
@@ -432,7 +432,6 @@ public class Config {
     default_map.put("tsd.core.meta.enable_realtime_uid", "false");
     default_map.put("tsd.core.meta.enable_tsuid_incrementing", "false");
     default_map.put("tsd.core.meta.enable_tsuid_tracking", "false");
-    default_map.put("tsd.core.plugin_path", "");
     default_map.put("tsd.core.socket.timeout", "0");
     default_map.put("tsd.core.tree.enable_processing", "false");
     default_map.put("tsd.core.preload_uid_cache", "false");

--- a/test/META-INF/MANIFEST.MF
+++ b/test/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-

--- a/test/META-INF/services/net.opentsdb.plugin.DummyPlugin
+++ b/test/META-INF/services/net.opentsdb.plugin.DummyPlugin
@@ -1,2 +1,0 @@
-net.opentsdb.plugin.DummyPluginA
-net.opentsdb.plugin.DummyPluginB

--- a/test/META-INF/services/net.opentsdb.search.SearchPlugin
+++ b/test/META-INF/services/net.opentsdb.search.SearchPlugin
@@ -1,1 +1,0 @@
-net.opentsdb.search.DummySearchPlugin

--- a/test/META-INF/services/net.opentsdb.tsd.HttpSerializer
+++ b/test/META-INF/services/net.opentsdb.tsd.HttpSerializer
@@ -1,1 +1,0 @@
-net.opentsdb.tsd.DummyHttpSerializer

--- a/test/META-INF/services/net.opentsdb.tsd.RTPublisher
+++ b/test/META-INF/services/net.opentsdb.tsd.RTPublisher
@@ -1,1 +1,0 @@
-net.opentsdb.tsd.DummyRTPublisher

--- a/test/plugin/DummyPluginA.java
+++ b/test/plugin/DummyPluginA.java
@@ -12,10 +12,12 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.plugin;
 
+import com.google.auto.service.AutoService;
 import org.junit.Ignore;
 
 // need to ignore this class so JUnit doesn't try to run tests on it
 @Ignore
+@AutoService(DummyPlugin.class)
 public class DummyPluginA extends DummyPlugin {
   
   public DummyPluginA() {

--- a/test/plugin/DummyPluginB.java
+++ b/test/plugin/DummyPluginB.java
@@ -12,10 +12,12 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.plugin;
 
+import com.google.auto.service.AutoService;
 import org.junit.Ignore;
 
 // need to ignore this class so JUnit doesn't try to run tests on it
 @Ignore
+@AutoService(DummyPlugin.class)
 public class DummyPluginB extends DummyPlugin {
   
   public DummyPluginB() {

--- a/test/search/DummySearchPlugin.java
+++ b/test/search/DummySearchPlugin.java
@@ -18,8 +18,10 @@ import net.opentsdb.meta.TSMeta;
 import net.opentsdb.meta.UIDMeta;
 import net.opentsdb.stats.StatsCollector;
 
+import com.google.auto.service.AutoService;
 import com.stumbleupon.async.Deferred;
 
+@AutoService(SearchPlugin.class)
 public final class DummySearchPlugin extends SearchPlugin {
 
   @Override

--- a/test/search/TestSearchPlugin.java
+++ b/test/search/TestSearchPlugin.java
@@ -49,7 +49,6 @@ public final class TestSearchPlugin {
             .build();
 
     // setups a good default for the config
-    PluginLoader.loadJAR("plugin_test.jar");
     search = PluginLoader.loadSpecificPlugin(
         "net.opentsdb.search.DummySearchPlugin", SearchPlugin.class);
   }

--- a/test/tsd/DummyHttpSerializer.java
+++ b/test/tsd/DummyHttpSerializer.java
@@ -14,6 +14,7 @@ package net.opentsdb.tsd;
 
 import net.opentsdb.core.TSDB;
 
+import com.google.auto.service.AutoService;
 import com.stumbleupon.async.Deferred;
 import org.junit.Ignore;
 
@@ -22,6 +23,7 @@ import org.junit.Ignore;
  * @since 2.0
  */
 @Ignore
+@AutoService(HttpSerializer.class)
 public class DummyHttpSerializer extends HttpSerializer {
 
   public DummyHttpSerializer() {

--- a/test/tsd/DummyRTPublisher.java
+++ b/test/tsd/DummyRTPublisher.java
@@ -18,8 +18,10 @@ import net.opentsdb.core.TSDB;
 import net.opentsdb.meta.Annotation;
 import net.opentsdb.stats.StatsCollector;
 
+import com.google.auto.service.AutoService;
 import com.stumbleupon.async.Deferred;
 
+@AutoService(RTPublisher.class)
 public final class DummyRTPublisher extends RTPublisher {
 
   @Override

--- a/test/tsd/TestHttpQuery.java
+++ b/test/tsd/TestHttpQuery.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import net.opentsdb.core.TSDB;
-import net.opentsdb.utils.PluginLoader;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -719,7 +718,6 @@ public final class TestHttpQuery {
   
   @Test
   public void setSerializerDummyQS() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
     HttpQuery.initializeSerializerMaps(tsdb);
     HttpQuery query = NettyMocks.getQuery(tsdb, "/aggregators?serializer=dummy");
     query.setSerializer();
@@ -742,7 +740,6 @@ public final class TestHttpQuery {
   
   @Test
   public void setSerializerDummyCT() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
     HttpQuery.initializeSerializerMaps(tsdb);
     final Channel channelMock = NettyMocks.fakeChannel();
     final HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, 

--- a/test/tsd/TestRTPublisher.java
+++ b/test/tsd/TestRTPublisher.java
@@ -44,7 +44,6 @@ public final class TestRTPublisher {
             .withStore(new MemoryStore())
             .build();
 
-    PluginLoader.loadJAR("plugin_test.jar");
     rt_publisher = PluginLoader.loadSpecificPlugin(
         "net.opentsdb.tsd.DummyRTPublisher", RTPublisher.class);
   }

--- a/test/utils/TestPluginLoader.java
+++ b/test/utils/TestPluginLoader.java
@@ -12,70 +12,18 @@
 // see <http://www.gnu.org/licenses/>.
 package net.opentsdb.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.io.FileNotFoundException;
 import java.util.List;
 
 import net.opentsdb.plugin.DummyPlugin;
-import net.opentsdb.utils.PluginLoader;
 
 import org.junit.Test;
 
-public final class TestPluginLoader {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-  @Test
-  public void loadJar() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
-  }
-  
-  @Test (expected = FileNotFoundException.class)
-  public void loadJarDoesNotExist() throws Exception {
-    PluginLoader.loadJAR("jardoesnotexist.jar");
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void loadJarDoesNotAJar() throws Exception {
-    PluginLoader.loadJAR("notajar.png");
-  }
-  
-  @Test (expected = NullPointerException.class)
-  public void loadJarNull() throws Exception {
-    PluginLoader.loadJAR(null);
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void loadJarEmpty() throws Exception {
-    PluginLoader.loadJAR("");
-  }
-  
-  // todo - test for security exceptions?
-  
-  @Test
-  public void loadJars() throws Exception {
-    PluginLoader.loadJARs("./");
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void loadJarsDoesNotExist() throws Exception {
-    PluginLoader.loadJARs("./dirdoesnotexist");
-  }
-  
-  @Test (expected = NullPointerException.class)
-  public void loadJarsNull() throws Exception {
-    PluginLoader.loadJARs(null);
-  }
-  
-  @Test (expected = IllegalArgumentException.class)
-  public void loadJarsEmpty() throws Exception {
-    PluginLoader.loadJARs("");
-  }
-  
+public final class TestPluginLoader {
   @Test
   public void loadSpecificPlugin() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
     DummyPlugin plugin = PluginLoader.loadSpecificPlugin(
         "net.opentsdb.plugin.DummyPluginA", 
         DummyPlugin.class);
@@ -85,7 +33,6 @@ public final class TestPluginLoader {
   
   @Test (expected = IllegalArgumentException.class)
   public void loadSpecificPluginImplementationNotFound() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
     PluginLoader.loadSpecificPlugin(
         "net.opentsdb.plugin.DummyPluginC", 
         DummyPlugin.class);
@@ -93,7 +40,6 @@ public final class TestPluginLoader {
 
   @Test (expected = IllegalArgumentException.class)
   public void loadSpecificPluginNotFound() throws Exception {
-    PluginLoader.loadJAR("plugin_test.jar");
     PluginLoader.loadSpecificPlugin(
         "net.opentsdb.plugin.DummyPluginC", 
         DummyPluginBad.class);


### PR DESCRIPTION
This PR removes the ability to load JARs after JVM startup. It uses reflection to get a private method and it has been unstable for us on different platforms, also it is not really needed. One can get the same functionality by adding a directory or JAR to the command that starts the JVM.