### PR TITLE
Remove explicit checks for whether tables exist.

### DIFF
--- a/src/core/TSDB.java
+++ b/src/core/TSDB.java
@@ -178,17 +178,6 @@ public class TSDB {
   }
 
   /**
-   * Verifies that the data and UID tables exist in TsdbStore and optionally the
-   * tree and meta data tables if the user has enabled meta tracking or tree
-   * building
-   * @return An ArrayList of objects to wait for
-   * @since 2.0
-   */
-  public Deferred<ArrayList<Object>> checkNecessaryTablesExist() {
-    return tsdb_store.checkNecessaryTablesExist();
-  }
-
-  /**
    * Forces a flush of any un-committed in memory data including left over 
    * compactions.
    * <p>

--- a/src/storage/TsdbStore.java
+++ b/src/storage/TsdbStore.java
@@ -51,8 +51,6 @@ public interface TsdbStore {
    */
   Deferred<Annotation> getAnnotation(byte[] tsuid, long start_time);
 
-  public Deferred<ArrayList<Object>> checkNecessaryTablesExist();
-
   public Deferred<Object> flush();
 
   public Deferred<ArrayList<KeyValue>> get(final GetRequest request);

--- a/src/storage/cassandra/CassandraStore.java
+++ b/src/storage/cassandra/CassandraStore.java
@@ -164,11 +164,6 @@ public class CassandraStore implements TsdbStore {
   }
 
   @Override
-  public Deferred<ArrayList<Object>> checkNecessaryTablesExist() {
-    return null;
-  }
-
-  @Override
   public Deferred<Object> flush() {
     return null;
   }

--- a/src/storage/hbase/HBaseStoreDescriptor.java
+++ b/src/storage/hbase/HBaseStoreDescriptor.java
@@ -3,6 +3,8 @@ package net.opentsdb.storage.hbase;
 import com.codahale.metrics.MetricRegistry;
 import com.google.auto.service.AutoService;
 
+import com.stumbleupon.async.Callback;
+import com.stumbleupon.async.Deferred;
 import net.opentsdb.stats.Metrics;
 import net.opentsdb.storage.TsdbStore;
 import net.opentsdb.storage.StoreDescriptor;
@@ -10,11 +12,15 @@ import net.opentsdb.utils.Config;
 
 import org.hbase.async.HBaseClient;
 
+import java.util.ArrayList;
+
 @AutoService(StoreDescriptor.class)
 public class HBaseStoreDescriptor extends StoreDescriptor {
   @Override
   public TsdbStore createStore(final Config config, final Metrics metrics) {
     final HBaseClient client = createHBaseClient(config);
+    checkNecessaryTablesExist(client, config);
+
     final HBaseStore store = new HBaseStore(client, config);
 
     MetricRegistry registry = metrics.getRegistry();
@@ -31,8 +37,60 @@ public class HBaseStoreDescriptor extends StoreDescriptor {
    * @return Returns a HBaseStore object ready for use.
    */
   private HBaseClient createHBaseClient(final Config config) {
-    return new HBaseClient(
-                    config.getString("tsd.storage.hbase.zk_quorum"),
-                    config.getString("tsd.storage.hbase.zk_basedir"));
+    HBaseClient client = new HBaseClient(
+            config.getString("tsd.storage.hbase.zk_quorum"),
+            config.getString("tsd.storage.hbase.zk_basedir"));
+
+    client.setFlushInterval(config.getShort("tsd.storage.flush_interval"));
+
+    return client;
+  }
+
+
+  private void checkNecessaryTablesExist(final HBaseClient client,
+                                         final Config config) {
+    final boolean enable_tree_processing = config.enable_tree_processing();
+    final boolean enable_realtime_ts = config.enable_realtime_ts();
+    final boolean enable_realtime_uid = config.enable_realtime_uid();
+    final boolean enable_tsuid_incrementing = config.enable_tsuid_incrementing();
+
+    Deferred<Object> d = checkTableExists(client,
+            config.getString("tsd.storage.hbase.data_table"));
+
+    d = checkTableExists(client,
+            config.getString("tsd.storage.hbase.uid_table"), d);
+
+    if (enable_tree_processing) {
+      d = checkTableExists(client,
+              config.getString("tsd.storage.hbase.tree_table"), d);
+    }
+    if (enable_realtime_ts ||
+        enable_realtime_uid ||
+        enable_tsuid_incrementing) {
+      d = checkTableExists(client,
+              config.getString("tsd.storage.hbase.meta_table"), d);
+    }
+
+    try {
+      d.joinUninterruptibly();
+    } catch (Exception e) {
+      throw new IllegalStateException("One or more tables are probably missing", e);
+    }
+  }
+
+  private Deferred<Object> checkTableExists(final HBaseClient client,
+                                            final String table) {
+    return client.ensureTableExists(table.getBytes(HBaseConst.CHARSET));
+  }
+
+  private Deferred<Object> checkTableExists(final HBaseClient client,
+                                            final String table,
+                                            Deferred<Object> d) {
+    return d.addCallbackDeferring(new Callback<Deferred<Object>, Object>() {
+      @Override
+      public Deferred<Object> call(final Object arg) throws Exception {
+        return checkTableExists(client, table);
+      }
+    });
   }
 }

--- a/src/tools/CliQuery.java
+++ b/src/tools/CliQuery.java
@@ -79,7 +79,6 @@ final class CliQuery {
     Config config = CliOptions.getConfig(argp);
     
     final TSDB tsdb = TsdbBuilder.createFromConfig(config).build();
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
     final String basepath = argp.get("--graph");
     argp = null;
 

--- a/src/tools/DumpSeries.java
+++ b/src/tools/DumpSeries.java
@@ -79,7 +79,6 @@ final class DumpSeries {
     
     final TSDB tsdb = TsdbBuilder.createFromConfig(config).build();
     formatter = new UidFormatter(tsdb);
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
     final byte[] table = config.getString("tsd.storage.hbase.data_table").getBytes();
     final boolean delete = argp.has("--delete");
     final boolean importformat = delete || argp.has("--import");

--- a/src/tools/Fsck.java
+++ b/src/tools/Fsck.java
@@ -1113,7 +1113,6 @@ final class Fsck {
     if (queries.isEmpty() && !argp.has("--full-scan")) {
       usage(argp, "Must supply a query or use the '--full-scan' flag", 1);
     }
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
      
     argp = null;
     final Fsck fsck = new Fsck(tsdb, options);

--- a/src/tools/Search.java
+++ b/src/tools/Search.java
@@ -69,7 +69,6 @@ final class Search {
     
     Config config = CliOptions.getConfig(argp);
     final TSDB tsdb = TsdbBuilder.createFromConfig(config).build();
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
     
     int rc;
     try {
@@ -128,10 +127,6 @@ final class Search {
   private static int lookup(final TSDB tsdb,
                             final boolean use_data_table,
                             final String[] args) throws Exception {
-    if (!use_data_table) {
-      tsdb.checkNecessaryTablesExist().joinUninterruptibly();
-    }
-    
     final SearchQuery query = new SearchQuery();
     query.setType(SearchType.LOOKUP);
     

--- a/src/tools/TSDMain.java
+++ b/src/tools/TSDMain.java
@@ -142,9 +142,6 @@ final class TSDMain {
     TSDB tsdb = null;
     try {
       tsdb = TsdbBuilder.createFromConfig(config).build();
-      
-      // Make sure we don't even start if we can't find our tables.
-      tsdb.checkNecessaryTablesExist().joinUninterruptibly();
 
       registerShutdownHook(tsdb);
       final ServerBootstrap server = new ServerBootstrap(factory);

--- a/src/tools/TextImporter.java
+++ b/src/tools/TextImporter.java
@@ -77,7 +77,6 @@ final class TextImporter {
         .convertDurationsTo(TimeUnit.MILLISECONDS)
         .build();
 
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
     argp = null;
     try {
       int points = 0;

--- a/src/tools/UidManager.java
+++ b/src/tools/UidManager.java
@@ -118,7 +118,6 @@ final class UidManager {
       .getBytes();
     
     final TSDB tsdb = TsdbBuilder.createFromConfig(config).build();
-    tsdb.checkNecessaryTablesExist().joinUninterruptibly();
     argp = null;
     int rc;
     try {
@@ -180,7 +179,6 @@ final class UidManager {
       // check for the data table existence and initialize our plugins 
       // so that update meta data can be pushed to search engines
       try {
-        tsdb.checkNecessaryTablesExist().joinUninterruptibly();
         return metaSync(tsdb);
       } catch (Exception e) {
         LOG.error("Unexpected exception", e);
@@ -190,7 +188,6 @@ final class UidManager {
       // check for the data table existence and initialize our plugins 
       // so that update meta data can be pushed to search engines
       try {
-        tsdb.checkNecessaryTablesExist().joinUninterruptibly();
         return metaPurge(tsdb);
       } catch (Exception e) {
         LOG.error("Unexpected exception", e);
@@ -199,7 +196,6 @@ final class UidManager {
     } else if (args[0].equals("treesync")) {
       // check for the UID table existence
       try {
-        tsdb.checkNecessaryTablesExist().joinUninterruptibly();
         if (!tsdb.getConfig().enable_tree_processing()) {
           LOG.warn("Tree processing is disabled");
           return 0;
@@ -215,7 +211,6 @@ final class UidManager {
         return 2;
       }
       try {
-        tsdb.checkNecessaryTablesExist().joinUninterruptibly();
         final int tree_id = Integer.parseInt(args[1]);
         final boolean delete_definitions;
         if (nargs < 3) {

--- a/test/storage/MemoryStore.java
+++ b/test/storage/MemoryStore.java
@@ -131,11 +131,6 @@ public class MemoryStore implements TsdbStore {
   }
 
   @Override
-  public Deferred<ArrayList<Object>> checkNecessaryTablesExist() {
-    throw new UnsupportedOperationException("Not implemented yet");
-  }
-
-  @Override
   public Deferred<Object> flush() {
     return Deferred.fromResult(null);
   }


### PR DESCRIPTION
Instead we rely on the store to throw an exception if anything is wrong.